### PR TITLE
Added "sandbox_high" case reference of map to Component.cs and SettingsHandler.cs

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -104,6 +104,7 @@ namespace AILimit
                     botDistance = AILimitPlugin.customsDistance.Value;
                     break;
                 case "sandbox":
+                case "sandbox_high":
                     botDistance = AILimitPlugin.groundZeroDistance.Value;
                     break;
                 case "interchange":

--- a/SettingsHandler.cs
+++ b/SettingsHandler.cs
@@ -17,6 +17,7 @@ namespace dvize.AILimit
                     AILimitComponent.botDistance = AILimitPlugin.customsDistance.Value;
                     break;
                 case "sandbox":
+                case "sandbox_high":
                     AILimitComponent.botDistance = AILimitPlugin.groundZeroDistance.Value;
                     break;
                 case "interchange":


### PR DESCRIPTION
Was testing your latest release and noticed nothing applied to Ground Zero Level 20 (sandbox_high).